### PR TITLE
Ruta en navbar para aliados

### DIFF
--- a/services/web/src/components/contents/AdminIndexPageContent/index.tsx
+++ b/services/web/src/components/contents/AdminIndexPageContent/index.tsx
@@ -73,10 +73,8 @@ export function AdminIndexPageContent() {
           <Tab>Superadmins</Tab>
           <Tab>Supervisores</Tab>
           <Tab>Tutores</Tab>
-          <Tab>Aliadxs</Tab>
         </TabList>
         <TabPanels>
-          <TabPanel>{null}</TabPanel>
           <TabPanel>{null}</TabPanel>
           <TabPanel>{null}</TabPanel>
           <TabPanel>{null}</TabPanel>

--- a/services/web/src/lib/routes/index.tsx
+++ b/services/web/src/lib/routes/index.tsx
@@ -1,6 +1,6 @@
 import { UserRoleName } from "lib/types/role";
 import React from "react";
-import { FiHome, FiUsers } from "react-icons/fi";
+import { FiHome, FiStar, FiUsers } from "react-icons/fi";
 
 interface IRoute {
   title: string;
@@ -14,6 +14,11 @@ const routes: { [key in UserRoleName]?: IRoute[] } = {
       title: "Inicio",
       route: "/dashboard",
       icon: <FiHome />,
+    },
+    {
+      title: "Aliados",
+      route: "/allies",
+      icon: <FiStar />,
     },
   ],
   [UserRoleName.ALLY]: [
@@ -33,6 +38,11 @@ const routes: { [key in UserRoleName]?: IRoute[] } = {
       title: "Usuarios",
       route: "/admin",
       icon: <FiUsers />,
+    },
+    {
+      title: "Aliados",
+      route: "/allies",
+      icon: <FiStar />,
     },
   ],
   [UserRoleName.TUTOR]: [


### PR DESCRIPTION
Se puso en el navbar, se quito el tab de allies en la pestaña de usuarios, ya que los aliados no son usuarios.